### PR TITLE
Fix minor bug when --no_genbank is used where `nextclade_col_list` is unset

### DIFF
--- a/viral_usher/viral_usher_build.py
+++ b/viral_usher/viral_usher_build.py
@@ -685,6 +685,7 @@ def make_metadata_header(ncbi_header, nextclade_clade_columns, remove_segment, e
         midx = None
     # Add numerical date column
     metadata_header += '\tnum_date'
+    nextclade_col_list = []
     if nextclade_clade_columns:
         nextclade_col_list = get_nextclade_column_list(nextclade_clade_columns)
         metadata_header += '\t' + '\t'.join(nextclade_col_list)


### PR DESCRIPTION
I was getting errors using `--no_genbank` as there is a branch that I think can leave `nextclade_col_list` unset but we use `len(nextclade_col_list)` in the return statement for this function.