### PR TITLE
Allow option to specify URLs instead of paths

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -50,7 +50,7 @@ jobs:
         mkdir -p tests/test_data/output
         cat > tests/test_data/test_config_ci.toml <<EOF
         taxonomy_id = '12345'
-        ref_fasta = '$(pwd)/tests/test_data/ref.fa'
+        ref_fasta = 'https://raw.githubusercontent.com/AngieHinrichs/viral_usher/refs/heads/main/tests/test_data/ref.fa'
         ref_gbff = '$(pwd)/tests/test_data/ref.gbff'
         extra_fasta = '$(pwd)/tests/test_data/sequences.fa'
         workdir = '$(pwd)/tests/test_data/output'


### PR DESCRIPTION
This would allow URLs to (alternatively) be specified in the config instead of paths - they would then get downloaded by the docker image while reading in the config and the downloaded files used. The existing test is modified to provide coverage of this functionality.

This would:

- make the web version a bit simpler to implement as it would no longer need an init container
- maybe be useful to other users too?

Therefore it seemed to me like it might be worth throwing in, but if you prefer not, all good!