### PR TITLE
Add original_metadata config key for existing tree metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,4 @@ changed_nodes
 !tests/test_data/*.fa
 !tests/test_data/*.gbff
 !tests/test_data/*.toml
+.venv/

--- a/tests/test_original_metadata.py
+++ b/tests/test_original_metadata.py
@@ -1,0 +1,212 @@
+"""Tests for the original_metadata feature in finalize_metadata_from_original."""
+import gzip
+import json
+import os
+import tempfile
+import pytest
+from viral_usher.viral_usher_build import (
+    finalize_metadata_from_original,
+    get_extra_metadata,
+    make_taxonium_config,
+    open_maybe_decompress,
+)
+
+
+@pytest.fixture
+def workdir():
+    """Create a temporary working directory."""
+    old_cwd = os.getcwd()
+    with tempfile.TemporaryDirectory() as tmpdir:
+        os.chdir(tmpdir)
+        yield tmpdir
+        os.chdir(old_cwd)
+
+
+@pytest.fixture
+def original_metadata_file(workdir):
+    """Create a sample original metadata.tsv.gz with tree sequence metadata."""
+    path = os.path.join(workdir, "original_metadata.tsv.gz")
+    with gzip.open(path, 'wt') as f:
+        f.write("strain\tnum_date\taccession\tcountry\tdate\n")
+        f.write("USA/seq1|ACC001|2024-01-15\t2024.041096\tACC001\tUSA\t2024-01-15\n")
+        f.write("GBR/seq2|ACC002|2024-03-20\t2024.218579\tACC002\tGBR\t2024-03-20\n")
+        f.write("FRA/seq3|ACC003|2024-06-01\t2024.415301\tACC003\tFRA\t2024-06-01\n")
+    return path
+
+
+@pytest.fixture
+def sample_names_file(workdir):
+    """Create a sample_names file listing sequences in the final tree."""
+    path = os.path.join(workdir, "tree_samples.txt")
+    with open(path, 'w') as f:
+        # Two existing sequences + one new sequence from extra_fasta
+        f.write("USA/seq1|ACC001|2024-01-15\n")
+        f.write("GBR/seq2|ACC002|2024-03-20\n")
+        f.write("new_sample_1\n")
+    return path
+
+
+@pytest.fixture
+def extra_metadata_file(workdir):
+    """Create a simple extra_metadata file for new sequences."""
+    path = os.path.join(workdir, "extra_metadata.tsv")
+    with open(path, 'w') as f:
+        f.write("name\tcountry\tdate\n")
+        f.write("new_sample_1\tJPN\t2024-07-01\n")
+    return path
+
+
+def test_basic_original_metadata(workdir, original_metadata_file, sample_names_file):
+    """Test that original_metadata produces valid output with correct columns and rows."""
+    metadata_out, rename_out, date_min, date_max, extra_added, extra_mapped = \
+        finalize_metadata_from_original(
+            original_metadata_file, sample_names_file,
+            extra_fasta_names=None, extra_metadata='', extra_metadata_date_column='')
+
+    assert os.path.exists(metadata_out)
+    assert os.path.exists(rename_out)
+
+    # Read the output metadata
+    with gzip.open(metadata_out, 'rt') as f:
+        lines = f.readlines()
+
+    # Header + 2 existing sequences (seq3 not in sample_names)
+    assert len(lines) == 3
+    header = lines[0].strip().split('\t')
+    assert header == ['strain', 'num_date', 'accession', 'country', 'date']
+
+    # Check first row
+    row1 = lines[1].strip().split('\t')
+    assert row1[0] == 'USA/seq1|ACC001|2024-01-15'
+    assert row1[2] == 'ACC001'
+    assert row1[3] == 'USA'
+
+    # Check date range
+    assert date_min is not None
+    assert date_max is not None
+    assert date_min < date_max
+
+    # No extra cols since original_metadata defines the schema
+    assert extra_added == []
+    assert extra_mapped == {}
+
+
+def test_original_metadata_with_extra_fasta(workdir, original_metadata_file, sample_names_file):
+    """Test that new sequences from extra_fasta get rows with empty fields."""
+    extra_fasta_names = {'new_sample_1', 'new_sample_not_in_tree'}
+
+    metadata_out, rename_out, date_min, date_max, _, _ = \
+        finalize_metadata_from_original(
+            original_metadata_file, sample_names_file,
+            extra_fasta_names=extra_fasta_names, extra_metadata='',
+            extra_metadata_date_column='')
+
+    with gzip.open(metadata_out, 'rt') as f:
+        lines = f.readlines()
+
+    # Header + 2 existing + 1 new (new_sample_not_in_tree not in tree)
+    assert len(lines) == 4
+    new_row = lines[3].strip().split('\t')
+    assert new_row[0] == 'new_sample_1'
+    # All other fields should be empty (no extra_metadata provided)
+    assert all(v == '' for v in new_row[1:])
+
+
+def test_original_metadata_with_extra_fasta_and_metadata(
+        workdir, original_metadata_file, sample_names_file, extra_metadata_file):
+    """Test that extra_metadata values are mapped into original_metadata columns for new sequences."""
+    extra_fasta_names = {'new_sample_1'}
+
+    metadata_out, rename_out, date_min, date_max, _, _ = \
+        finalize_metadata_from_original(
+            original_metadata_file, sample_names_file,
+            extra_fasta_names=extra_fasta_names, extra_metadata=extra_metadata_file,
+            extra_metadata_date_column='date')
+
+    with gzip.open(metadata_out, 'rt') as f:
+        lines = f.readlines()
+
+    header = lines[0].strip().split('\t')
+    assert len(lines) == 4
+    new_row = lines[3].strip().split('\t')
+    assert new_row[0] == 'new_sample_1'
+
+    # 'country' column should be mapped from extra_metadata
+    country_idx = header.index('country')
+    assert new_row[country_idx] == 'JPN'
+
+    # 'date' column should be mapped from extra_metadata
+    date_idx = header.index('date')
+    assert new_row[date_idx] == '2024-07-01'
+
+    # 'num_date' should be computed from the date
+    num_date_idx = header.index('num_date')
+    assert float(new_row[num_date_idx]) > 2024.0
+
+
+def test_original_metadata_filters_by_sample_names(workdir, original_metadata_file, sample_names_file):
+    """Test that only sequences in sample_names are included in output."""
+    metadata_out, _, _, _, _, _ = \
+        finalize_metadata_from_original(
+            original_metadata_file, sample_names_file,
+            extra_fasta_names=None, extra_metadata='', extra_metadata_date_column='')
+
+    with gzip.open(metadata_out, 'rt') as f:
+        lines = f.readlines()
+
+    # seq3 (FRA) is in original_metadata but NOT in sample_names -> excluded
+    strains = [line.strip().split('\t')[0] for line in lines[1:]]
+    assert 'FRA/seq3|ACC003|2024-06-01' not in strains
+    assert 'USA/seq1|ACC001|2024-01-15' in strains
+    assert 'GBR/seq2|ACC002|2024-03-20' in strains
+
+
+def test_original_metadata_no_duplicate_columns(workdir, original_metadata_file, sample_names_file):
+    """Test that the output header has no duplicate columns (the original bug)."""
+    metadata_out, _, _, _, _, _ = \
+        finalize_metadata_from_original(
+            original_metadata_file, sample_names_file,
+            extra_fasta_names=None, extra_metadata='', extra_metadata_date_column='')
+
+    with gzip.open(metadata_out, 'rt') as f:
+        header = f.readline().strip().split('\t')
+
+    # No duplicates
+    assert len(header) == len(set(header)), f"Duplicate columns found: {header}"
+
+
+def test_make_taxonium_config_with_original_metadata_cols(workdir):
+    """Test that make_taxonium_config uses original_metadata_cols for color_by_options."""
+    original_cols = ['strain', 'num_date', 'accession', 'country', 'date']
+    config_path = make_taxonium_config(
+        date_min=2024.0, date_max=2024.5,
+        nextclade_clade_columns='', got_extra_fasta=True,
+        no_genbank=True, extra_added_cols=[], extra_mapped_cols={},
+        original_metadata_cols=original_cols)
+
+    with open(config_path, 'r') as f:
+        config = json.load(f)
+
+    color_by = config['colorBy']['colorByOptions']
+    # Should include meta_ prefixed columns from original_metadata (excluding 'strain')
+    assert 'meta_num_date' in color_by
+    assert 'meta_country' in color_by
+    assert 'meta_date' in color_by
+    assert 'meta_accession' in color_by
+    # Should NOT include strain (it's the index column)
+    assert 'meta_strain' not in color_by
+
+
+def test_make_taxonium_config_without_original_metadata(workdir):
+    """Test that make_taxonium_config still works without original_metadata_cols."""
+    config_path = make_taxonium_config(
+        date_min=2024.0, date_max=2024.5,
+        nextclade_clade_columns='', got_extra_fasta=True,
+        no_genbank=True, extra_added_cols=[], extra_mapped_cols={})
+
+    with open(config_path, 'r') as f:
+        config = json.load(f)
+
+    # Should still produce valid config
+    assert 'colorBy' in config
+    assert 'colorByOptions' in config['colorBy']

--- a/viral_usher/config.py
+++ b/viral_usher/config.py
@@ -123,7 +123,7 @@ def parse_config(config_path, resolve_url_keys=True, no_genbank=False):
 
     if resolve_url_keys:
         # Resolve paths that can be URLs
-        url_resolvable_keys = ['ref_fasta', 'ref_gbff', 'extra_fasta', 'extra_metadata', 'update_tree_input', 'taxonium_overlay_html']
+        url_resolvable_keys = ['ref_fasta', 'ref_gbff', 'extra_fasta', 'extra_metadata', 'original_metadata', 'update_tree_input', 'taxonium_overlay_html']
         for key in url_resolvable_keys:
             if key in config:
                 config[key] = handle_path_or_url(config[key])

--- a/viral_usher/viral_usher_build.py
+++ b/viral_usher/viral_usher_build.py
@@ -801,6 +801,103 @@ def add_extra_metadata_rows(m_out, midx, metadata_header, sample_names, nextclad
     return date_min, date_max
 
 
+def finalize_metadata_from_original(original_metadata, sample_names, extra_fasta_names,
+                                    extra_metadata, extra_metadata_date_column):
+    """When original_metadata (the existing tree's metadata.tsv.gz) is provided, use it as the
+    source of metadata for existing sequences.  New sequences from extra_fasta get rows with
+    values from extra_metadata if provided, otherwise empty fields."""
+    rename_out = "rename.tsv"
+    metadata_out = "metadata.tsv.gz"
+    start_time = start_timing(f"Finalizing metadata from original_metadata, writing to {metadata_out}...")
+    date_min = None
+    date_max = None
+
+    # Read sample names (sequences in the final tree)
+    sample_names_set = set()
+    with open(sample_names, 'r') as sn:
+        for line in sn:
+            sample_names_set.add(line.strip())
+
+    # Read original metadata header and rows
+    orig_header = None
+    orig_rows = {}
+    with open_maybe_decompress(original_metadata) as om:
+        orig_header = om.readline().rstrip('\n').split('\t')
+        for line in om:
+            fields = line.rstrip('\n').split('\t')
+            if fields:
+                orig_rows[fields[0]] = fields
+
+    # Find num_date column index if present
+    num_date_idx = orig_header.index('num_date') if 'num_date' in orig_header else None
+
+    # Read extra metadata for new sequences (if provided)
+    extra_metadata_cols, extra_metadata_rows = get_extra_metadata(extra_metadata)
+
+    # Map extra metadata columns to original metadata header positions
+    extra_col_map = {}  # orig_header index -> extra_metadata column name
+    if extra_metadata_cols:
+        for col in extra_metadata_cols:
+            mapped_col = col
+            if col == extra_metadata_date_column:
+                mapped_col = 'date'
+            if mapped_col in orig_header:
+                extra_col_map[orig_header.index(mapped_col)] = col
+
+    header_line = '\t'.join(orig_header) + '\n'
+
+    with open(rename_out, 'w') as r_out, gzip.open(metadata_out, 'wt') as m_out:
+        m_out.write(header_line)
+
+        # Write rows for existing sequences that are in the final tree
+        for name, fields in orig_rows.items():
+            if name not in sample_names_set:
+                continue
+            m_out.write('\t'.join(fields) + '\n')
+            # No renaming needed — original metadata already uses display names
+            if num_date_idx is not None and num_date_idx < len(fields) and fields[num_date_idx]:
+                try:
+                    nd = float(fields[num_date_idx])
+                    if date_min is None or nd < date_min:
+                        date_min = nd
+                    if date_max is None or nd > date_max:
+                        date_max = nd
+                except ValueError:
+                    pass
+
+        # Write rows for new extra_fasta sequences that are in the final tree
+        if extra_fasta_names:
+            for name in extra_fasta_names:
+                if name not in sample_names_set:
+                    continue
+                extra_row = extra_metadata_rows.get(name, {})
+                fields = [name]
+                for i, col in enumerate(orig_header[1:], 1):
+                    if i in extra_col_map and extra_col_map[i] in extra_row:
+                        val = extra_row[extra_col_map[i]]
+                    elif col in extra_row:
+                        val = extra_row[col]
+                    elif col == 'num_date' and extra_metadata_date_column:
+                        # Compute num_date from the date column in extra_metadata
+                        date_col = extra_metadata_date_column
+                        date_val = extra_row.get(date_col, '')
+                        nd = get_numerical_date(date_val) if date_val else 0.0
+                        val = f"{nd:.6f}" if nd else ''
+                        if nd:
+                            if date_min is None or nd < date_min:
+                                date_min = nd
+                            if date_max is None or nd > date_max:
+                                date_max = nd
+                    else:
+                        val = ''
+                    fields.append(val)
+                m_out.write('\t'.join(fields) + '\n')
+
+    finish_timing(start_time)
+    # extra_added_cols and extra_mapped_cols are empty since original_metadata defines the schema
+    return metadata_out, rename_out, date_min, date_max, [], {}
+
+
 def finalize_metadata(ncbi_virus_metadata, nextclade_assignments, nextclade_clade_columns, ref_segment, sample_names,
                       extra_fasta_names, extra_metadata, extra_metadata_date_column):
     """Make a file for renaming sequence names in tree to include country, isolate name and date when available.
@@ -883,16 +980,13 @@ def get_header(tsv_in):
 
 
 def make_taxonium_config(date_min, date_max, nextclade_clade_columns, got_extra_fasta, no_genbank, extra_added_cols,
-                         extra_mapped_cols):
+                         extra_mapped_cols, original_metadata_cols=None):
     """Make a config file with a color gradient from date_min to date_max."""
     config_out = "taxonium_config.json"
-    if no_genbank:
-        color_by_options = []
-        if extra_mapped_cols:
-            color_by_options += ["meta_" + col for col in extra_mapped_cols.keys()]
-        if 'date' in extra_mapped_cols:
-            color_by_options.append("meta_num_date")
-    else:
+    if original_metadata_cols:
+        # Use columns from original_metadata (excluding 'strain' which is the index)
+        color_by_options = ["meta_" + col for col in original_metadata_cols if col != 'strain']
+    elif no_genbank:
         color_by_options = ["meta_country", "meta_location", "meta_num_date", "meta_host", "meta_serotype"]
         if got_extra_fasta is not None:
             color_by_options.append("meta_source")
@@ -989,14 +1083,15 @@ def make_taxonium_overlay_html(config_contents, ref_acc, no_genbank, got_extra_f
 
 
 def usher_to_taxonium(pb_in, metadata_in, ref_gbff, tip_count, species, ref_acc, date_min, date_max,
-                      nextclade_clade_columns, no_genbank, extra_added_cols, extra_mapped_cols, config_contents):
+                      nextclade_clade_columns, no_genbank, extra_added_cols, extra_mapped_cols, config_contents,
+                      original_metadata_cols=None):
     jsonl_out = "tree.jsonl.gz"
     start_time = start_timing(f"Running usher_to_taxonium to make {jsonl_out}...")
     columns = ','.join(get_header(metadata_in))
-    title = f"{tip_count} {species} sequences from GenBank aligned to {ref_acc}"
+    title = f"{tip_count} {species or 'unknown'} sequences aligned to {ref_acc}"
     got_extra_fasta = bool(config_contents.get('extra_fasta', ''))
     config = make_taxonium_config(date_min, date_max, nextclade_clade_columns, got_extra_fasta, no_genbank,
-                                  extra_added_cols, extra_mapped_cols)
+                                  extra_added_cols, extra_mapped_cols, original_metadata_cols)
     overlay_html = config_contents.get('taxonium_overlay_html', '')
     if not overlay_html:
         overlay_html = make_taxonium_overlay_html(config_contents, ref_acc, no_genbank, got_extra_fasta)
@@ -1108,6 +1203,7 @@ def main():
     extra_fasta = config_contents.get('extra_fasta', '')
     extra_metadata = config_contents.get('extra_metadata', '')
     extra_metadata_date_column = config_contents.get('extra_metadata_date_column', '')
+    original_metadata = config_contents.get('original_metadata', '')
     update_tree_input = config_contents.get('update_tree_input', optimized_pb)
     if update_tree_input == "":
         update_tree_input = optimized_pb
@@ -1165,14 +1261,25 @@ def main():
     nextclade_assignments, nextclade_clade_columns = run_nextclade(nextclade_path, nextclade_clade_columns,
                                                                    existing_nextclade_assignments, existing_column_count,
                                                                    genbank_fasta, extra_fasta, ref_fasta)
-    metadata_tsv, rename_tsv, date_min, date_max, extra_added_cols, extra_mapped_cols = \
-        finalize_metadata(ncbi_virus_metadata, nextclade_assignments, nextclade_clade_columns, ref_segment,
-                          sample_names, extra_fasta_names, extra_metadata, extra_metadata_date_column)
+    if original_metadata:
+        metadata_tsv, rename_tsv, date_min, date_max, extra_added_cols, extra_mapped_cols = \
+            finalize_metadata_from_original(original_metadata, sample_names, extra_fasta_names,
+                                            extra_metadata, extra_metadata_date_column)
+    else:
+        metadata_tsv, rename_tsv, date_min, date_max, extra_added_cols, extra_mapped_cols = \
+            finalize_metadata(ncbi_virus_metadata, nextclade_assignments, nextclade_clade_columns, ref_segment,
+                              sample_names, extra_fasta_names, extra_metadata, extra_metadata_date_column)
     viz_tree = rename_seqs(opt_tree, rename_tsv)
     dump_newick(viz_tree)
     write_output_stats(ref_acc, ref_length, gb_count, filtered_count, aligned_count, tree_tip_count)
+    # Read original_metadata header for taxonium config color_by_options
+    original_metadata_cols = None
+    if original_metadata:
+        with open_maybe_decompress(original_metadata) as om:
+            original_metadata_cols = om.readline().rstrip('\n').split('\t')
     usher_to_taxonium(viz_tree, metadata_tsv, ref_gbff, tree_tip_count, species, ref_acc, date_min, date_max,
-                      nextclade_clade_columns, args.no_genbank, extra_added_cols, extra_mapped_cols, config_contents)
+                      nextclade_clade_columns, args.no_genbank, extra_added_cols, extra_mapped_cols, config_contents,
+                      original_metadata_cols)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary
- Adds `original_metadata` config key that accepts a path/URL to the existing tree's `metadata.tsv.gz`
- When provided (typically in no-genbank mode with update), uses it as the source of metadata for existing tree sequences instead of building metadata from NCBI
- Avoids the duplicate `num_date` column bug that occurred when the tree's `metadata.tsv.gz` was incorrectly passed as `extra_metadata`
- New sequences from `extra_fasta` get rows with values mapped from `extra_metadata` into the original schema
- Also fixes title to show "unknown" instead of Python `None` when species lookup fails

## Use case
When using the "Place sequences" button on taxonium.org to place user sequences on an existing viral_usher tree, the tree's metadata should be preserved in the output. Previously, passing it as `extra_metadata` caused column duplication and `usher_to_taxonium` failure.

## Test plan
- [x] 7 new unit tests covering all scenarios (basic, with extra_fasta, with extra_metadata mapping, filtering, no duplicates, taxonium config)
- [x] All 17 tests pass (10 existing + 7 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)