### PR TITLE
Add support for apptainer, for when docker is not permitted.

### DIFF
--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -14,6 +14,7 @@ on:
       - "tests/test_data/**"
       - "Dockerfile"
       - "pyproject.toml"
+      - ".github/workflows/integration-test.yml"
 
 jobs:
   test:
@@ -48,8 +49,20 @@ jobs:
         python -m pip install --upgrade pip
         pip install -e .
 
-    - name: Run test script
+    - name: Run test script with docker
       run: |
+        mkdir -p tests/test_data/output
+        bash tests/test_${{ matrix.test_name }}.sh tests/test_data/output
+        rm -rf tests/test_data/output
+
+    - name: Install Apptainer
+      uses: eWaterCycle/setup-apptainer@v2
+      with:
+        apptainer-version: 1.5.1
+
+    - name: Run test script with apptainer
+      run: |
+        apptainer --version
         mkdir -p tests/test_data/output
         bash tests/test_${{ matrix.test_name }}.sh tests/test_data/output
         rm -rf tests/test_data/output

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -38,6 +38,7 @@ jobs:
         tags: angiehinrichs/viral_usher:development
         cache-from: type=gha
         cache-to: type=gha,mode=max
+        outputs: type=oci,dest=/tmp/viral_usher_apptainer
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -61,6 +62,8 @@ jobs:
         apptainer-version: 1.5.1
 
     - name: Run test script with apptainer
+      env:
+        APPTAINER_CONTAINER: oci:///tmp/viral_usher_apptainer
       run: |
         apptainer --version
         mkdir -p tests/test_data/output

--- a/.github/workflows/integration-test.yml
+++ b/.github/workflows/integration-test.yml
@@ -38,7 +38,7 @@ jobs:
         tags: angiehinrichs/viral_usher:development
         cache-from: type=gha
         cache-to: type=gha,mode=max
-        outputs: type=oci,dest=/tmp/viral_usher_apptainer
+        outputs: type=oci,dest=/tmp/viral_usher_apptainer.tar
 
     - name: Set up Python
       uses: actions/setup-python@v6
@@ -63,7 +63,7 @@ jobs:
 
     - name: Run test script with apptainer
       env:
-        APPTAINER_CONTAINER: oci:///tmp/viral_usher_apptainer
+        APPTAINER_CONTAINER: oci-archive:///tmp/viral_usher_apptainer.tar
       run: |
         apptainer --version
         mkdir -p tests/test_data/output

--- a/README.md
+++ b/README.md
@@ -9,14 +9,14 @@
 - Subcommands:
   - `init`: Generate a config file (interactive or via command line options)
   - `build`: Download sequences and build a tree, guided by the config file
-- Uses [Docker](https://www.docker.com/) for portability to laptops, servers, or cloud platforms
+- Uses a container (either [Apptainer](https://apptainer.org/) or [Docker](https://www.docker.com/) for portability to laptops, servers, or cloud platforms
 
 ---
 
 ## 📦 Installation
 
 0. Install prerequisites (if not already installed)
-- [Docker](https://www.docker.com/)
+- Either [Apptainer](https://apptainer.org/) or [Docker](https://www.docker.com/)
 - [Python](https://www.python.org/) version 3.11 or later (we highly recommend using an environment manager such as [venv](https://docs.python.org/3/library/venv.html), [miniconda](https://www.anaconda.com/docs/getting-started/miniconda/main), [mamba](https://mamba.readthedocs.io/en/latest/installation/mamba-installation.html) etc.)
 
 1. Install with pip (again, we highly recommended using an environment manager):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "Easily configure and run a pipeline to build a tree of virus geno
 authors = [{ name = "Angie Hinrichs", email = "hinrichs@ucsc.edu" }]
 readme = "README.md"
 requires-python = ">=3.11"
-dependencies = ["requests", "biopython", "docker"]
+dependencies = ["requests", "biopython"]
 classifiers = [
     "Programming Language :: Python :: 3",
     "Operating System :: OS Independent",

--- a/tests/test_ehdv_4.sh
+++ b/tests/test_ehdv_4.sh
@@ -16,13 +16,14 @@ time viral_usher init \
     -w $workdir \
     -c $workdir/config.toml
 
+CONTAINER_IMAGE=${APPTAINER_CONTAINER:-angiehinrichs/viral_usher:development}
 time viral_usher build \
-    -d angiehinrichs/viral_usher:development \
+    -d $CONTAINER_IMAGE \
     -c $workdir/config.toml
 
 # Now run build on the same config, but with --update
 time viral_usher build \
-    -d angiehinrichs/viral_usher:development \
+    -d $CONTAINER_IMAGE \
     -c $workdir/config.toml \
     -u
 

--- a/tests/test_ehdv_4_extra_fasta.sh
+++ b/tests/test_ehdv_4_extra_fasta.sh
@@ -16,13 +16,14 @@ time viral_usher init \
     -w $workdir \
     -c $workdir/config.toml
 
+CONTAINER_IMAGE=${APPTAINER_CONTAINER:-angiehinrichs/viral_usher:development}
 time viral_usher build \
-    -d angiehinrichs/viral_usher:development \
+    -d $CONTAINER_IMAGE \
     -c $workdir/config.toml
 
 # Again, with --update
 time viral_usher build \
-    -d angiehinrichs/viral_usher:development \
+    -d $CONTAINER_IMAGE \
     -c $workdir/config.toml \
     -u
 

--- a/tests/test_ehdv_4_extra_fasta_metadata.sh
+++ b/tests/test_ehdv_4_extra_fasta_metadata.sh
@@ -17,8 +17,9 @@ time viral_usher init \
     -w $workdir \
     -c $workdir/config.toml
 
+CONTAINER_IMAGE=${APPTAINER_CONTAINER:-angiehinrichs/viral_usher:development}
 time viral_usher build \
-    -d angiehinrichs/viral_usher:development \
+    -d $CONTAINER_IMAGE \
     -c $workdir/config.toml
 
 # TODO: make sure the generated metadata has the expected additional columns and
@@ -26,7 +27,7 @@ time viral_usher build \
 
 # Again, with --update
 time viral_usher build \
-    -d angiehinrichs/viral_usher:development \
+    -d $CONTAINER_IMAGE \
     -c $workdir/config.toml \
     -u
 

--- a/tests/test_ehdv_4_extra_fasta_metadata_viral_usher_trees.sh
+++ b/tests/test_ehdv_4_extra_fasta_metadata_viral_usher_trees.sh
@@ -19,8 +19,9 @@ time viral_usher init \
     -c $workdir/config.toml
 
 # I think --update is forced by --use_viral_usher_trees but use it anyway
+CONTAINER_IMAGE=${APPTAINER_CONTAINER:-angiehinrichs/viral_usher:development}
 time viral_usher build \
-    -d angiehinrichs/viral_usher:development \
+    -d $CONTAINER_IMAGE \
     -c $workdir/config.toml \
     -u
 

--- a/tests/test_ehdv_4_viral_usher_trees.sh
+++ b/tests/test_ehdv_4_viral_usher_trees.sh
@@ -16,13 +16,14 @@ time viral_usher init \
     --use_viral_usher_trees \
     -c $workdir/config.toml
 
+CONTAINER_IMAGE=${APPTAINER_CONTAINER:-angiehinrichs/viral_usher:development}
 time viral_usher build \
-    -d angiehinrichs/viral_usher:development \
+    -d $CONTAINER_IMAGE \
     -c $workdir/config.toml
 
 # Again, with --update
 time viral_usher build \
-    -d angiehinrichs/viral_usher:development \
+    -d $CONTAINER_IMAGE \
     -c $workdir/config.toml \
     -u
 

--- a/tests/test_no_genbank.sh
+++ b/tests/test_no_genbank.sh
@@ -18,7 +18,8 @@ workdir = '$workdir'
 EOF
 
 # Run build with test data
-viral_usher build --config $config --docker_image angiehinrichs/viral_usher:development --no_genbank
+CONTAINER_IMAGE=${APPTAINER_CONTAINER:-angiehinrichs/viral_usher:development}
+viral_usher build --config $config --docker_image $CONTAINER_IMAGE --no_genbank
 
 # Check outputs exist
 cd $workdir

--- a/tests/test_prrsv2_nextclade.sh
+++ b/tests/test_prrsv2_nextclade.sh
@@ -16,13 +16,14 @@ time viral_usher init \
     -w $workdir \
     -c $workdir/config.toml
 
+CONTAINER_IMAGE=${APPTAINER_CONTAINER:-angiehinrichs/viral_usher:development}
 time viral_usher build \
-    -d angiehinrichs/viral_usher:development \
+    -d $CONTAINER_IMAGE \
     -c $workdir/config.toml
 
 # Again, with --update
 time viral_usher build \
-    -d angiehinrichs/viral_usher:development \
+    -d $CONTAINER_IMAGE \
     -c $workdir/config.toml \
     -u
 

--- a/tests/test_prrsv2_nextclade_extra_fasta.sh
+++ b/tests/test_prrsv2_nextclade_extra_fasta.sh
@@ -18,13 +18,14 @@ time viral_usher init \
     -w $workdir \
     -c $workdir/config.toml
 
+CONTAINER_IMAGE=${APPTAINER_CONTAINER:-angiehinrichs/viral_usher:development}
 time viral_usher build \
-    -d angiehinrichs/viral_usher:development \
+    -d $CONTAINER_IMAGE \
     -c $workdir/config.toml
 
 # Again, with --update
 time viral_usher build \
-    -d angiehinrichs/viral_usher:development \
+    -d $CONTAINER_IMAGE \
     -c $workdir/config.toml \
     -u
 

--- a/tests/test_prrsv2_nextclade_extra_fasta_no_genbank.sh
+++ b/tests/test_prrsv2_nextclade_extra_fasta_no_genbank.sh
@@ -19,8 +19,9 @@ time viral_usher init \
     -c $workdir/config.toml
 
 # Just one update --no_genbank run so only extra fasta seqs are added
+CONTAINER_IMAGE=${APPTAINER_CONTAINER:-angiehinrichs/viral_usher:development}
 time viral_usher build \
-    -d angiehinrichs/viral_usher:development \
+    -d $CONTAINER_IMAGE \
     -c $workdir/config.toml \
     -u \
     --no_genbank

--- a/viral_usher/build.py
+++ b/viral_usher/build.py
@@ -1,7 +1,6 @@
 # 'build' subcommand: build a tree according to parameters in config file
 
 import datetime
-import docker
 import filecmp
 import importlib.metadata
 import os
@@ -14,50 +13,62 @@ docker_platform = 'linux/amd64'
 docker_workdir = '/data'
 
 
-def check_docker_command():
-    """Make sure we can run the docker command and connect to the docker server.  If there's a problem, return False with
-    an error message; otherwise return True with no message."""
+def choose_container_runtime():
+    """Detect available container runtime. Prefer Apptainer if available.
+    Returns a tuple (runtime, error_message). runtime is one of 'apptainer', 'docker' or None on failure."""
+    # Check for apptainer first (preferred)
+    try:
+        subprocess.run(['apptainer', '--version'], check=True, capture_output=True)
+        return 'apptainer', None
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        pass
+    # Fallback to docker CLI
     try:
         subprocess.run(['docker', '--help'], check=True, capture_output=True)
     except (subprocess.CalledProcessError, FileNotFoundError):
-        return False, "Unable to run 'docker --help' -- please install Docker from https://www.docker.com/ and try again."
+        return None, "Unable to run 'docker' or 'apptainer' -- please install one of them and try again."
     try:
         subprocess.run(['docker', 'images'], check=True, capture_output=True)
     except subprocess.CalledProcessError:
-        return False, "Unable to run 'docker images' -- please make sure the docker daemon is running (e.g. on a Mac, start the Docker app)"
-    return True, None
+        return None, "Unable to run 'docker images' -- please make sure the docker daemon is running (e.g. on a Mac, start the Docker app)"
+    return 'docker', None
 
 
-def pull_docker_image(client: docker.DockerClient, image_name: str):
-    """Pull the docker image corresponding to this version of the viral_usher python package unless it is already present."""
+def pull_docker_image_subprocess(image_name: str):
+    """Pull a docker image using the docker CLI."""
     try:
-        client.images.pull(image_name, platform=docker_platform)
-    except (docker.errors.ContainerError) as e:
-        print(f"Failed to pull docker container {image_name}:\n{e}", file=sys.stderr)
+        subprocess.run(['docker', 'pull', '--platform', docker_platform, image_name], check=True)
+    except subprocess.CalledProcessError as e:
+        print(f"Failed to pull docker image {image_name}:\n{e}", file=sys.stderr)
         sys.exit(1)
-    except (TimeoutError):
+    except TimeoutError:
         print("Timeout error while trying to pull docker image; maybe try again later?")
         sys.exit(1)
 
 
-def get_docker_image(client: docker.DockerClient, args_docker_image: str):
+def get_container_image(runtime: str, args_docker_image: str):
+    """Return an image reference appropriate for the runtime. For docker runtime, ensure the image exists locally (pull if needed).
+    For apptainer runtime, return a docker://... URI so apptainer can pull it on demand."""
     if args_docker_image:
-        try:
-            client.images.get(args_docker_image)
-            print(f"Using docker image {args_docker_image}")
-        except docker.errors.ImageNotFound:
-            print(f"Docker image '{args_docker_image}' not found.  Please try again with a different --docker_image value.", sys.stderr)
-        return args_docker_image
+        image_name = args_docker_image
     else:
         viral_usher_version = importlib.metadata.version('viral_usher')
         image_name = config.DEFAULT_DOCKER_IMAGE + ':v' + viral_usher_version
+
+    if runtime == 'docker':
+        # Check if image exists; if not, pull it
         try:
-            client.images.get(image_name)
+            subprocess.run(['docker', 'image', 'inspect', image_name], check=True, capture_output=True)
             print(f"Using docker image {image_name}")
-        except docker.errors.ImageNotFound:
+        except subprocess.CalledProcessError:
             print(f"Docker image {image_name} is not present, pulling it from DockerHub...")
-            pull_docker_image(client, image_name)
+            pull_docker_image_subprocess(image_name)
         return image_name
+    else:  # apptainer
+        # apptainer accepts docker://<image> URIs; ensure we return that form
+        if '://' in image_name:
+            return image_name
+        return f"docker://{image_name}"
 
 
 def maybe_copy_to_workdir(filepath, workdir):
@@ -124,52 +135,55 @@ def localize_config(args_config, config_contents, no_genbank):
     return config_rel
 
 
-def run_in_docker(workdir, config_rel, args_docker_image, args_update, args_no_genbank, args_threads):
-    """Start up a docker container that runs the pipeline."""
-    docker_client = docker.from_env()
+def run_in_container(runtime, workdir, config_rel, args_docker_image, args_update, args_no_genbank, args_threads):
+    """Run the pipeline using either docker CLI or apptainer CLI depending on runtime."""
     user_id = os.getuid()
     group_id = os.getgid()
-    docker_image = get_docker_image(docker_client, args_docker_image)
-    command = ["viral_usher_build", "--config", config_rel]
+    image_ref = get_container_image(runtime, args_docker_image)
+    base_command = ["viral_usher_build", "--config", config_rel]
     if args_update:
-        command.append("--update")
+        base_command.append("--update")
     if args_no_genbank:
-        command.append("--no_genbank")
+        base_command.append("--no_genbank")
     if args_threads:
-        command += ["--threads", str(args_threads)]
+        base_command += ["--threads", str(args_threads)]
+
+    if runtime == 'docker':
+        cmd = [
+            'docker', 'run', '--rm', '--platform', docker_platform,
+            '-w', docker_workdir,
+            '--network', 'host', '--user', f"{user_id}:{group_id}",
+            '-v', f"{workdir}:{docker_workdir}",
+        ] + [image_ref] + base_command
+    else:  # apptainer
+        # apptainer will pull docker:// images automatically; bind workdir
+        # Use 'exec' to run the command inside the image
+        cmd = [
+            'apptainer', 'exec', '--bind', f"{workdir}:{docker_workdir}",
+            '--pwd', docker_workdir,
+            image_ref
+        ] + base_command
+
     try:
-        container = docker_client.containers.run(
-            docker_image,
-            platform=docker_platform,
-            remove=True,
-            network_mode='host',
-            user=':'.join([str(user_id), str(group_id)]),
-            volumes=[':'.join([workdir, docker_workdir])],
-            command=command,
-            detach=True,  # Run container in background so we can stream logs
-            stdout=True,
-            stderr=True,
-            tty=True
-        )
-        # Stream logs in real time
-        for line in container.logs(stream=True):
-            print(line.decode(), end='')
-        exit_code = container.wait()['StatusCode']
-        if exit_code != 0:
-            print(f"docker container {docker_image} failed with exit code {exit_code}", file=sys.stderr)
-            sys.exit(exit_code)
-    except (docker.errors.ContainerError) as e:
-        print(f"docker container {docker_image} failed:\n{e}", file=sys.stderr)
+        proc = subprocess.Popen(cmd, stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True)
+        for line in proc.stdout:
+            print(line, end='')
+        proc.wait()
+        if proc.returncode != 0:
+            print(f"{runtime} container {image_ref} failed with exit code {proc.returncode}", file=sys.stderr)
+            sys.exit(proc.returncode)
+    except FileNotFoundError as e:
+        print(f"Failed to run container runtime: {e}", file=sys.stderr)
         sys.exit(1)
-    except (TimeoutError):
-        print("Timeout error while trying to run docker; maybe try again later?")
+    except TimeoutError:
+        print(f"Timeout error while trying to run {runtime}; maybe try again later?")
         sys.exit(1)
 
 
 def handle_build(args):
     """Set up input files in workdir, run pipeline in docker and check final results."""
-    ok, error = check_docker_command()
-    if not ok:
+    runtime, error = choose_container_runtime()
+    if runtime is None:
         print(f"\n{error}\n", file=sys.stderr)
         sys.exit(1)
     print(f"Running pipeline with config file: {args.config}")
@@ -181,7 +195,7 @@ def handle_build(args):
         sys.exit(1)
     config_rel = localize_config(args.config, config_contents, args.no_genbank)
     workdir = config_contents['workdir']
-    run_in_docker(workdir, config_rel, args.docker_image, args.update, args.no_genbank, args.threads)
+    run_in_container(runtime, workdir, config_rel, args.docker_image, args.update, args.no_genbank, args.threads)
     if os.path.exists(f"{workdir}/tree.jsonl.gz"):
         print(f"Success -- you can view {workdir}/tree.jsonl.gz using https://taxonium.org/ now.")
     else:


### PR DESCRIPTION
This was motivated by a comment in TurakhiaLab/WEPP#11 that viral_usher wasn't working and other comments in the same issue pointing to the reliance on Docker as a possible cause.  Since Docker requires a daemon with root privileges, there are many environments in which it is not allowed.  However, Apptainer is often allowed in those environments because it runs in userspace.  I can't completely replace Docker with Apptainer because Apptainer is Linux-only and I'm still relying on Docker to support Mac/ARM.

@theosanderson this should not affect any of your uses of viral_usher, but I wanted to give you a heads-up just in case.

Currently I'm relying on Apptainer's ability to convert docker images to its native format, not building a separate image for Apptainer.  That adds a bit of delay the first time that an image is used, but it appears to be cached after conversion so subsequent runs shouldn't be slowed down by that.